### PR TITLE
Changes Home Page to be Two Columns

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-background">
-        {children}
+        <main className="flex flex-col gap-12 p-12 h-screen">
+          <h1 className="self-center text-6xl text-foreground">
+            DJ Song Match!
+          </h1>
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,10 +27,15 @@ async function SongsAutoComplete() {
 
 export default function Home() {
   return (
-    <div className="flex flex-col gap-4 justify-center items-center h-screen">
-      <h1 className="text-6xl text-foreground">DJ Song Match!</h1>
-      <p className="text-2xl text-foreground">Begin by searching for a song.</p>
-      <SongsAutoComplete />
+    <div className="flex flex-row gap-24 h-full">
+      <div className="flex flex-col gap-4 grow-[1]">
+        <p className="text-2xl text-center text-foreground">
+          Search for a song!
+        </p>
+        <SongsAutoComplete />
+        <button className="self-center p-4 w-24 bg-green-200">Generate</button>
+      </div>
+      <p className="h-full bg-red-50 grow-[4]">Table goes here</p>
     </div>
   );
 }


### PR DESCRIPTION
- Moves logo to layout.tsx to make it persist throughout pages
- Gives table 4/5 of the screen width
- Gives search bar 1/5 of screen width
- No functionality at the moment
- Table will obviously be changed in the future to be an actual table

![image](https://github.com/user-attachments/assets/1441b451-9544-4ec2-9309-d8015e1152c1)