### PR TITLE
Fixes a Bug With Song.Key = 0

### DIFF
--- a/src/components/ui/SongForm.tsx
+++ b/src/components/ui/SongForm.tsx
@@ -19,7 +19,7 @@ export default function SongForm({ onFetchDataAction }: SongFormProps) {
   const { data } = useQuery({
     queryKey: ["song", songId],
     queryFn: async () => {
-      if (!songId) return;
+      if (songId == undefined) return;
       const song = await getSong(songId);
       if (song?.key == null || song?.key == undefined) return;
       return getSameKey(song.key);

--- a/src/components/ui/SongForm.tsx
+++ b/src/components/ui/SongForm.tsx
@@ -21,7 +21,7 @@ export default function SongForm({ onFetchDataAction }: SongFormProps) {
     queryFn: async () => {
       if (!songId) return;
       const song = await getSong(songId);
-      if (!song?.key) return;
+      if (song?.key == null || song?.key == undefined) return;
       return getSameKey(song.key);
     },
     enabled: !!songId,


### PR DESCRIPTION
![20250308_21h31m37s_grim](https://github.com/user-attachments/assets/c4920edb-6ae7-4a92-93ef-c9bb0e1d3177)
Example of bug

For some songs with Key = 0 in the database, the query for gathering similar songs would think it's invalid (because 0 is "falsey"). Added some more verbose null/undefined checking to fix this bug.