### PR TITLE
Adds Key Names to Table and Minor/Major, Fixes #41

### DIFF
--- a/src/components/ui/songtable.tsx
+++ b/src/components/ui/songtable.tsx
@@ -5,6 +5,23 @@ interface SongTableProps {
   songs: Song[];
 }
 
+// Song.Key in database represents index in this array.
+// So a song.key = 2 would be index 2 in this array, which is D
+const keyMap = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
+
 export default function SongTable({ songs }: SongTableProps) {
   return (
     <table className="w-full border border-gray-500 border-collapse">
@@ -40,10 +57,14 @@ export default function SongTable({ songs }: SongTableProps) {
               {song.artist}
             </td>
             <td className="p-3 border border-table_border text-table_text">
-              {song.tempo && Math.round(song.tempo)}
+              {song.tempo != null && Math.round(song.tempo)}
             </td>
             <td className="p-3 border border-table_border text-table_text">
-              {song.key}
+              {song.key != null && keyMap[song.key]}
+
+              {/* Song.Mode = 0 is minor, 1 is Major*/}
+              {song.mode != null && song.mode === 0 && "m"}
+              {/*Adds an "m" if the song is minor, otherwise nothing*/}
             </td>
           </tr>
         ))}


### PR DESCRIPTION
- Hardcodes a mapping of Key integers to Key strings
- Only changes the rendering of key in the table, doesn't affect database data itself
- Uses Song.mode to determine minor or major
- If song is minor adds a "m" after the key, if it's major, does nothing (A Major = `A`, A minor = `Am`)
- Adds some more verbose null checking to prevent unexpected bugs

![20250308_21h51m26s_grim](https://github.com/user-attachments/assets/c6ee80f0-60fc-4bc2-9315-e2c82706c4cb)