### PR TITLE
Add Major/Minor Relative Key Query

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -3,10 +3,14 @@
 // do NOT export components in this file, only functions
 
 import { musicData, Song } from "@/db/schema";
-import { and, eq, like, or, sql } from "drizzle-orm";
+import { and, eq, like, ne, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/libsql";
 
 const db = drizzle("file:./assets/ClassicHit.db");
+
+// constants for song.mode
+const MINOR = 0;
+const MAJOR = 1
 
 export async function getSong(songId: number) {
     const song = db

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -23,14 +23,35 @@ export async function getSong(songId: number) {
     return song;
 }
 
-export async function getSameKey(key: number) {
-    const sameKey = await db
+export async function getSameKey(song: Song, relativeKey: boolean = true) {
+    if (song.key === null || song.mode === null) return;
+
+    let relativeQuery = relativeKey
+        ? and(
+            ne(musicData.mode, song.mode),
+
+            // if song is major, go back 3 half steps to get relative minor
+            // if song is minor, go forward 3 half steps to get relative major
+            // mod 12 because 12 total tones
+            eq(musicData.key, (song.mode === MAJOR ? song.key - 3 : song.key + 3) % 12)
+        )
+        : undefined; // if relativeKey=false, just ignore query
+
+    return db
         .select()
         .from(musicData)
-        .where(eq(musicData.key, key))
+        .where(
+            or(
+                and(
+                    // checks that same song and mode
+                    eq(musicData.mode, song.mode),
+                    eq(musicData.key, song.key)
+                ),
+                relativeQuery
+            )
+        )
         .orderBy(sql`RANDOM()`)
         .limit(10); // arbitary limit
-    return sameKey;
 }
 
 export async function searchSongs(query: string) {

--- a/src/components/ui/SongForm.tsx
+++ b/src/components/ui/SongForm.tsx
@@ -21,8 +21,8 @@ export default function SongForm({ onFetchDataAction }: SongFormProps) {
     queryFn: async () => {
       if (!songId) return;
       const song = await getSong(songId);
-      if (!song?.key) return;
-      return getSameKey(song.key);
+      if (song == undefined) return;
+      return getSameKey(song);
     },
     enabled: !!songId,
   });


### PR DESCRIPTION
- Adds logic to fill up table data with relative major/minor
- Passing `relativeKey=false` into `getSameKey()` disables this behavior, but by default relative keys are enabled
- Added some constants for `MAJOR` and `MINOR` modes for clarity
- Now passes entire song data into `getSameKey()` instead of just the key