### PR TITLE
Adds Helpful Tooltip Next to Slider Label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@radix-ui/react-slider": "^1.2.3",
                 "@radix-ui/react-slot": "^1.1.2",
                 "@radix-ui/react-switch": "^1.1.3",
+                "@radix-ui/react-tooltip": "^1.1.8",
                 "@tanstack/react-query": "^5.66.11",
                 "babel-plugin-react-compiler": "^19.0.0-beta-bafa41b-20250307",
                 "class-variance-authority": "^0.7.1",
@@ -1500,6 +1501,40 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-tooltip": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.8.tgz",
+            "integrity": "sha512-YAA2cu48EkJZdAMHC0dqo9kialOcRStbtiY4nJPaht7Ptrhcvpo+eDChaM6BIs8kL6a8Z5l5poiqLnXcNduOkA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.1",
+                "@radix-ui/react-compose-refs": "1.1.1",
+                "@radix-ui/react-context": "1.1.1",
+                "@radix-ui/react-dismissable-layer": "1.1.5",
+                "@radix-ui/react-id": "1.1.0",
+                "@radix-ui/react-popper": "1.2.2",
+                "@radix-ui/react-portal": "1.1.4",
+                "@radix-ui/react-presence": "1.1.2",
+                "@radix-ui/react-primitive": "2.0.2",
+                "@radix-ui/react-slot": "1.1.2",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "@radix-ui/react-visually-hidden": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-use-callback-ref": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1613,6 +1648,29 @@
             },
             "peerDependenciesMeta": {
                 "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-visually-hidden": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
+            "integrity": "sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.0.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
                     "optional": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -9,15 +9,16 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "@babel/runtime": "^7.26.10",
         "@libsql/client": "^0.14.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-slider": "^1.2.3",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.3",
+        "@radix-ui/react-tooltip": "^1.1.8",
         "@tanstack/react-query": "^5.66.11",
         "babel-plugin-react-compiler": "^19.0.0-beta-bafa41b-20250307",
-        "@babel/runtime": "^7.26.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",

--- a/src/app/_components/ButtonSliderSection.tsx
+++ b/src/app/_components/ButtonSliderSection.tsx
@@ -3,7 +3,14 @@
 import "@/app/globals.css";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Song } from "@/db/schema";
+import { CircleHelpIcon } from "lucide-react";
 import { useState } from "react";
 
 interface SliderMarkerProps {
@@ -71,7 +78,23 @@ function SongSlider({
         max={1}
         step={0.01}
       />
-      {label}
+      <div className="flex gap-1 items-center">
+        {label}
+
+        {/* Only show icon when tooltip !== null*/}
+        {tooltip !== null && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <CircleHelpIcon size={18} />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="w-max max-w-3xs">{tooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
     </div>
   );
 }
@@ -83,11 +106,13 @@ function SliderArea({ inputSong }: { inputSong: Song | null }) {
         label="Energy"
         defaultValue={[0.5]}
         markValue={inputSong && inputSong.energy ? inputSong.energy : null}
+        tooltip="This is a really long tooltip. Basically, we got this data from spotify, so we didn't generate the metrics ourselves. We could reference the Spotify API to understand it, tho"
       />
       <SongSlider
         label="Loudness"
         defaultValue={[0.42]}
         markValue={inputSong && inputSong.loudness ? inputSong.loudness : null}
+        tooltip={null}
       />
       <SongSlider
         label="Danceability"
@@ -95,6 +120,7 @@ function SliderArea({ inputSong }: { inputSong: Song | null }) {
         markValue={
           inputSong && inputSong.danceability ? inputSong.danceability : null
         }
+        tooltip="short"
       />
     </section>
   );

--- a/src/app/_components/ButtonSliderSection.tsx
+++ b/src/app/_components/ButtonSliderSection.tsx
@@ -37,10 +37,13 @@ interface SongSliderProps {
 }
 
 function SliderMarker({ label, markValue }: SliderMarkerProps) {
+  /**
+   * SliderMarker is a component that displays a marker on the slider.
+   * - A marker is a visual indicator that renders a "tick" and a label above the slider.
+   * - The marker is only displayed when markValue is not null.
+   */
   return (
     <div className="w-full max-w-4xl">
-      {/* markValue could be null, meaning an input song is not selected*/}
-      {/* if no input song, don't display markers */}
       {markValue != null && (
         <div className="relative">
           <div
@@ -66,6 +69,13 @@ function SongSlider({
   markValue,
   tooltip = null,
 }: SongSliderProps) {
+  /**
+   * SongSlider is a component that displays a slider with a label and a tooltip.
+   * - The slider is used to adjust the value of the song metric
+   * - The label is displayed above the slider.
+   * - The tooltip is displayed when the user hovers over the slider.
+   */
+
   const [value, setValue] = useState(defaultValue);
 
   return (
@@ -78,7 +88,7 @@ function SongSlider({
         max={1}
         step={0.01}
       />
-      <div className="flex gap-1 items-center">
+      <div className="flex overflow-hidden gap-1 items-center">
         {label}
 
         {/* Only show icon when tooltip !== null*/}
@@ -88,8 +98,11 @@ function SongSlider({
               <TooltipTrigger>
                 <CircleHelpIcon size={18} />
               </TooltipTrigger>
-              <TooltipContent>
-                <p className="w-max max-w-3xs">{tooltip}</p>
+              <TooltipContent
+                sideOffset={4}
+                className="p-2 max-w-lg translate-y-3 w-fit text-pretty"
+              >
+                {tooltip}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -100,6 +113,10 @@ function SongSlider({
 }
 
 function SliderArea({ inputSong }: { inputSong: Song | null }) {
+  /**
+   * SliderArea is a component that contains all of the Slider components on the main page
+   */
+
   return (
     <section className="flex flex-col gap-8 grow">
       <SongSlider
@@ -127,6 +144,9 @@ function SliderArea({ inputSong }: { inputSong: Song | null }) {
 }
 
 function ButtonArea() {
+  /**
+   * ButtonArea is a component that contains the two buttons on the main page
+   */
   return (
     <section className="flex flex-col gap-4 justify-center items-center min-w-[150px]">
       <Button variant={"outline"} className="w-full">
@@ -138,6 +158,9 @@ function ButtonArea() {
 }
 
 function ButtonSliderSection({ inputSong }: { inputSong: Song | null }) {
+  /**
+   * ButtonSliderSection is a component that contains the SliderArea and ButtonArea components
+   */
   return (
     <section className="pt-8 w-full max-w-4xl">
       <div className="flex flex-col gap-6 p-8 rounded-lg border md:flex-row border-border shadow-xs">

--- a/src/app/_components/ButtonSliderSection.tsx
+++ b/src/app/_components/ButtonSliderSection.tsx
@@ -13,18 +13,20 @@ interface SliderMarkerProps {
    *
    */
   label: string;
-  markValue: number | null;
+  markValue?: number | null;
 }
 
 interface SongSliderProps {
   /**
-   * @param label - The label above the slider
    * @param defaultValue - The default value of the slider
+   * @param label - The label above the slider
    * @param markValue - The value on the slider (from 0 to 1) to add a marker like "Input Song"
+   * @param tooltip - The message to display when hovering over the tooltip
    */
-  label: string;
   defaultValue: number[];
+  label: string;
   markValue: number | null;
+  tooltip?: string | null;
 }
 
 function SliderMarker({ label, markValue }: SliderMarkerProps) {
@@ -51,7 +53,12 @@ function SliderMarker({ label, markValue }: SliderMarkerProps) {
   );
 }
 
-function SongSlider({ label, defaultValue, markValue }: SongSliderProps) {
+function SongSlider({
+  label,
+  defaultValue,
+  markValue,
+  tooltip = null,
+}: SongSliderProps) {
   const [value, setValue] = useState(defaultValue);
 
   return (

--- a/src/app/_components/ButtonSliderSection.tsx
+++ b/src/app/_components/ButtonSliderSection.tsx
@@ -113,7 +113,7 @@ function SongSlider({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
-                <CircleHelpIcon size={18} />
+                <CircleHelpIcon size={18} className="text-muted-foreground" />
               </TooltipTrigger>
               <TooltipContent
                 sideOffset={4}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-neutral-900 text-neutral-50 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance dark:bg-neutral-50 dark:text-neutral-900",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-neutral-900 fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] dark:bg-neutral-50" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -36,7 +36,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  side = "bottom",
+  side = "right",
   sideOffset = 0,
   children,
   ...props
@@ -48,7 +48,7 @@ function TooltipContent({
         side={side}
         sideOffset={sideOffset}
         className={cn(
-          "bg-muted text-muted-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-muted text-muted-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-full max-w-full origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -36,6 +36,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
+  side = "bottom",
   sideOffset = 0,
   children,
   ...props
@@ -44,18 +45,18 @@ function TooltipContent({
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
+        side={side}
         sideOffset={sideOffset}
         className={cn(
-          "bg-neutral-900 text-neutral-50 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance dark:bg-neutral-50 dark:text-neutral-900",
-          className
+          "bg-muted text-muted-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-neutral-900 fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] dark:bg-neutral-50" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function TooltipProvider({
   delayDuration = 0,
@@ -15,7 +15,7 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
 function Tooltip({
@@ -25,13 +25,13 @@ function Tooltip({
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
     </TooltipProvider>
-  )
+  );
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -58,4 +58,4 @@ function TooltipContent({
   )
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION

- Adds a tooltip that could show info about what slider metrics mean when the user hover's over the icon
- Passing `null` as the `tooltip` prop of `SongSlider` component skips tooltip icon from rendering

I'd appreciate input on the appearance of the tooltip content. I'm not 100% satisfied with the width and look of the tooltip content popup.

![20250319_13h28m34s_grim](https://github.com/user-attachments/assets/9e7187e1-1972-4d67-8ca3-27767121272f)
![20250319_13h27m33s_grim](https://github.com/user-attachments/assets/2ca6090c-1ae4-49c6-8511-017fcdeee638)