### PR TITLE
Disables React Compiler For Dev

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,14 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-    /* config options here */
-    experimental: {
-        reactCompiler: true,
-    },
-    compiler: {
-        // Remove console.log() on client in production builds
-        removeConsole: process.env.NODE_ENV === "production",
-    },
+  /* config options here */
+  experimental: {
+    // Optimize React in production builds
+    reactCompiler: process.env.NODE_ENV === "production",
+  },
+  compiler: {
+    // Remove console.log() on client in production builds
+    removeConsole: process.env.NODE_ENV === "production",
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
* I initially added React Compiler because it increases our app's performance (reducing re-renders) without us having to do additional work
* However, many people (including me) have been noticing that it is significantly increasing the time it takes for the server to start
* This change will enable React Compiler **only on production builds** (such as `pnpm build`)
* This should make it much easier to iterate on changes quickly and be more productive

### Notes
* There _may_ be differences between the compiled and non-compiled versions of our app, but we could also choose _not_ to compile in production in the future.