### PR TITLE
Bug fix for displaying key int instead of key string in playlist table, fix #88. Update seed.py to prevent duplicate seeding.

### DIFF
--- a/backend/api/database/seed.py
+++ b/backend/api/database/seed.py
@@ -93,6 +93,9 @@ def seed_songs_from_csv(csv_path: str) -> int:
     Returns: Number of successfully inserted songs
     """
     df = pd.read_csv(csv_path)
+
+    df = df.drop_duplicates(subset=["Artist", "Track"])
+
     songs = [
         Song(
             song_id=row['Song_ID'],
@@ -115,7 +118,7 @@ def seed_songs_from_csv(csv_path: str) -> int:
             popularity=row['Popularity'],
             genre=row['Genre']
         )
-        for _, row in df.drop_duplicates().iterrows()
+        for _, row in df.iterrows()
     ]
     return _bulk_insert_songs(songs)
 

--- a/frontend/app/_components/PlaylistTable.tsx
+++ b/frontend/app/_components/PlaylistTable.tsx
@@ -64,7 +64,7 @@ function SortableSongRow({
       <TableCell>
         <TitleArtist title={song.title} artist={song.artist} />
       </TableCell>
-      <TableCell className="text-right">{song.camelotKeyId}</TableCell>
+      <TableCell className="text-right">{song.camelotKeyStr}</TableCell>
       <TableCell className="text-right">{Math.round(song.tempo)}</TableCell>
       <TableCell className="pr-4 pl-8">
         <Tooltip disableHoverableContent={true}>


### PR DESCRIPTION
- Update PlaylistTable.tsx to display key string rather than camelot key int value
- Updates seed.py to avoid seeding songs into the db that have the same artist + title