### PR TITLE
Auto-Scroll Playlist to Bottom When Song Gets Added, Resolves #95

### DIFF
--- a/frontend/app/_components/PlaylistTable.tsx
+++ b/frontend/app/_components/PlaylistTable.tsx
@@ -21,7 +21,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { CircleMinusIcon, GripVerticalIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import TitleArtist from "./TitleArtist";
 
 function SortableSongRow({
@@ -117,8 +117,24 @@ export default function PlaylistTable() {
        * This is because it re-adds the event listener every time the component re-renders.
        */
       window.removeEventListener("addSongPlaylist", getPlaylist);
+      TableContainerRef.current?.scrollTo(0, 0);
     };
   }, []);
+
+  /* Reference to the container for the table.
+   * More info at @/components/ui/table.tsx and below in useEffect */
+  const TableContainerRef = useRef<HTMLDivElement>(null);
+
+  /* We need to use a separate useEffect from the one above because the table scrolls to the
+   * bottom _before_ the playlist is updated/rerendered. This means that the scroll position
+   * will incorrectly be at the second-to-last row of the table, which is not what we want.
+   * Instead, we wait for the playlist to be updated/rerender before scrolling to the bottom. */
+  useEffect(() => {
+    TableContainerRef.current?.scrollTo(
+      0,
+      TableContainerRef.current?.scrollHeight,
+    );
+  }, [playlist]);
 
   const removeSong = (song: SongWithUuid) => {
     /* The most up to date playlist (with the removed song) */
@@ -160,7 +176,10 @@ export default function PlaylistTable() {
           items={playlist.map((song) => song.uuid)}
           strategy={verticalListSortingStrategy}
         >
-          <Table className="border border-border">
+          <Table
+            refTableContainer={TableContainerRef}
+            className="border border-border"
+          >
             <TableHeader className="relative">
               <TableRow className="sticky top-0 text-xl text-secondary-foreground bg-secondary hover:bg-secondary">
                 <TableHead className="font-bold"></TableHead>

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -4,15 +4,25 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({
+  className,
+  refTableContainer,
+  refTable,
+  ...props
+}: React.ComponentProps<"table"> & {
+  refTableContainer?: React.RefObject<HTMLDivElement>;
+  refTable?: React.RefObject<HTMLTableElement>;
+}) {
   return (
     <div
       data-slot="table-container"
       className="overflow-x-auto relative w-full"
+      ref={refTableContainer}
     >
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}
+        ref={refTable}
         {...props}
       />
     </div>


### PR DESCRIPTION
- Adds more refs to `<Table>` in `@/components/ui/table.tsx` so that we could target the elements for scrollbar manipulation
  -  `refTableContainer?`: Optional Ref for the `table-container` `<div>`
  -  `refTable?`: Optional Ref for the table itself `<table>`
- The implementation uses a second `useEffect` hook to wait for the playlist to re-render before scrolling to bottom 

### Bugs
- When user refreshes the page, it also automatically scrolls to bottom of playlist table
  - Is this behavior we want?
  - How much do we care about this?

##### Issues Resolved
- Resolves #95 