### PR TITLE
Implement Docker hot reload feature and change pip to uv for install dependencies.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,27 +1,30 @@
 # Use Python 3.11
 FROM python:3.11-slim
 
-# Container's working directory
-#   All following commands (COPY, RUN, CMD, etc) execute here
+# Set working directory
 WORKDIR /app
 
+# Install uv dependencies and uv itself
+RUN apt-get update && \
+    apt-get install -y curl build-essential && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    /root/.local/bin/uv --version && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Add uv to PATH
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy the dependency list and install using uv
 COPY ./backend/requirements.txt ./requirements.txt
+RUN uv pip install --system -r requirements.txt
 
-# Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy the backend code into the container
+# Copy the backend code
 COPY ./backend ./backend
 
-# Expose network port for Flask development server
 EXPOSE 5001
 
-# Environment variables
-#   - FLASK_APP: Points to our create_app() function in backend/api/__init__.py
-#   - PYTHONUNBUFFERED: Better log output
+# Environment config
 ENV FLASK_APP=backend.api:create_app
 ENV PYTHONUNBUFFERED=1
 
-# Run Flask
-# CMD ["flask", "run", "--host=0.0.0.0", "--port=5001"]
 CMD ["python", "-m", "backend.api"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,26 +4,36 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: nextjs_app
+    working_dir: /app/frontend
     ports:
       - "3000:3000"
     depends_on:
       - backend
     volumes:
-      - ./frontend:/app/frontend
-      - /app/frontend/node_modules
+      - ./frontend:/app/frontend:cached
+      - frontend_node_modules:/app/frontend/node_modules
       - ./.env:/app/.env
     environment:
       - NODE_ENV=development
       - NEXT_PUBLIC_API_URL=http://backend:5001
-    command: ["sh", "-c", "pnpm dev"]
+      - WATCHPACK_POLLING=true
+    command: ["sh", "-c", "pnpm install && pnpm dev"]
+
   backend:
     build:
       context: .
       dockerfile: ./backend/Dockerfile
     container_name: python_backend
+    working_dir: /app/backend
     ports:
       - "5001:5001"
     volumes:
+      - ./backend:/app/backend:cached
       - ./.env:/app/.env
     environment:
       - FLASK_ENV=development
+      - FLASK_APP=backend.api:create_app
+      - PYTHONUNBUFFERED=1
+
+volumes:
+  frontend_node_modules:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# Base image with pnpm support
 FROM node:20-slim AS base
 
 # Setup pnpm
@@ -5,25 +6,28 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
+# Set working directory
+WORKDIR /workspace/frontend
 
-WORKDIR /app
-
+# Copy package files first (use Docker layer caching)
 COPY package.json pnpm-lock.yaml ./
 
 FROM base AS deps
+
+# Use cache mount for pnpm store (faster rebuilds)
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-# Conditionally install @libsql/linux-arm64-musl on ARM64
+
+# Conditionally install driver for ARM64
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then pnpm add @libsql/linux-arm64-musl; fi
 
-# Main build stage
 FROM base
 
-# Set environment
 ENV NODE_ENV=development
+WORKDIR /workspace/frontend
 
 # Copy installed node_modules from deps stage
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /workspace/frontend/node_modules ./node_modules
 
-# Copy rest of the app
+# Copy the rest of frontend
 COPY . .


### PR DESCRIPTION
Summary
- Replaced pip with uv in the backend Dockerfile for faster Python dependency installs
- Added WATCHPACK_POLLING=true to enable live-reloading in Docker

Possible Changes
- Might remove runtime pnpm install from frontend container to improve startup speed, but can cause dependency issues. Not best practice.